### PR TITLE
ci: Cancel in-progress GitHub Actions workflow on repeated pushes

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -6,6 +6,10 @@ on:
       - v1.x
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   screenshot-ubuntu:
     name: Screenshot (Ubuntu)

--- a/.github/workflows/screenshot.yml
+++ b/.github/workflows/screenshot.yml
@@ -8,6 +8,10 @@ on:
   # Allows running this workflow manually from the Actions tab
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   screenshot-ubuntu:
     name: Screenshot (Ubuntu)


### PR DESCRIPTION
Using `jobs.<job_id>.concurrency` ensures that only a single job or workflow using the same concurrency group will run at a time.

This means that after updating a given branch, the on-going build will be cancelled ensuring the available runners are used to build the latest version.

See https://docs.github.com/en/actions/using-jobs/using-concurrency

Adapted from scikit-build/scikit-build@f0db9f31f (ci: cancel in-progress on repeated pushes)