### PR TITLE
ci: Update dependabot settings to only check "dev-dependencies"

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,9 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      dev-dependencies:
+        dependency-type: "development"
+        update-types:
+        - "patch"
+        - "minor"


### PR DESCRIPTION
Ensure "check-dist" workflow does not systematically break when a pull request related to regular dependencies is proposed.

Updating of regular dependencies along with update of "dist/index.js" is expected to be done by maintainers.

Adapted from https://github.com/github/dependabot-action/blob/7f2c761b07a03b8893c27f7cbc46a42aa8d6e8cb/.github/dependabot.yml